### PR TITLE
Fixup cloud saves

### DIFF
--- a/ITDSWrapper.Desktop/Program.cs
+++ b/ITDSWrapper.Desktop/Program.cs
@@ -37,8 +37,11 @@ sealed class Program
                         SteamInputDriver inputDriver = new();
                         ((App)b.Instance!).InputDrivers = [inputDriver];
                         ((App)b.Instance).Updater = new SteamUpdater(inputDriver);
-                        ((App)b.Instance).LogInterpreter = new SteamLogInterpreter(inputDriver);
-                        SteamSaveManager.DownloadCloudSave();
+                        SteamLogInterpreter logInterpreter = new(inputDriver)
+                        {
+                            WatchForSdCreate = SteamSaveManager.DownloadCloudSave(),
+                        };
+                        ((App)b.Instance).LogInterpreter = logInterpreter;
                     }
                     catch (Exception ex)
                     {

--- a/ITDSWrapper.Desktop/Steam/SteamLogInterpreter.cs
+++ b/ITDSWrapper.Desktop/Steam/SteamLogInterpreter.cs
@@ -24,6 +24,12 @@ public class SteamLogInterpreter(SteamInputDriver inputDriver) : LogInterpreter
         {
             return wrapperPrefixLocation;
         }
+        if (wrapperPrefixLocation == 0 && WatchForSdCreate)
+        {
+            WatchForSdCreate = false;
+            SteamSaveManager.DownloadCloudSave();
+            return -1;
+        }
 
         int startIndex = wrapperPrefixLocation + WrapperLogPrefix.Length;
         int endIndex = log.IndexOf(':', startIndex);

--- a/ITDSWrapper.Desktop/Steam/SteamSaveManager.cs
+++ b/ITDSWrapper.Desktop/Steam/SteamSaveManager.cs
@@ -79,11 +79,4 @@ public static class SteamSaveManager
 
         return false;
     }
-
-    private static long GetNext16KMultiple(long length)
-    {
-        int i = 1;
-        for (; length > 0x1000000 * (long)Math.Pow(2, i); i++) ;
-        return 0x1000000 * (long)Math.Pow(2, i);
-    }
 }

--- a/ITDSWrapper.Desktop/Steam/SteamSaveManager.cs
+++ b/ITDSWrapper.Desktop/Steam/SteamSaveManager.cs
@@ -12,7 +12,6 @@ namespace ITDSWrapper.Desktop.Steam;
 public static class SteamSaveManager
 {
     private const string SaveFileName = "into-the-dream-spring.sav";
-    private const string SdCardHeaderName = "sd_header.bin";
     private static readonly string SaveDir = RetroWrapper.GetDirectoryForPlatform("saves");
     
     
@@ -30,8 +29,6 @@ public static class SteamSaveManager
         byte[] savFile = new byte[savStream.Length];
         savStream.ReadExactly(savFile);
         SteamRemoteStorage.FileWrite(SaveFileName, savFile);
-
-        SteamRemoteStorage.FileWrite(SdCardHeaderName, sdCardBytes[..0x7E00]);
     }
     
     public static bool DownloadCloudSave()

--- a/ITDSWrapper/Core/LogInterpreter.cs
+++ b/ITDSWrapper/Core/LogInterpreter.cs
@@ -5,9 +5,12 @@ namespace ITDSWrapper.Core;
 public class LogInterpreter
 {
     protected const string WrapperLogPrefix = "[WRAPPER] ";
-    
+    public bool WatchForSdCreate { get; set; }
+
     public virtual int InterpretLog(string log)
     {
-        return log.IndexOf(WrapperLogPrefix, StringComparison.Ordinal);
+        // The SD card is initialized after the game boots -- if we replace the SD card image here, it will load properly
+        return WatchForSdCreate && log.Contains("[melonDS] Game is now booting") ? 0 :
+            log.IndexOf(WrapperLogPrefix, StringComparison.Ordinal);
     }
 }

--- a/ITDSWrapper/ViewModels/MainViewModel.cs
+++ b/ITDSWrapper/ViewModels/MainViewModel.cs
@@ -94,13 +94,15 @@ public class MainViewModel : ViewModelBase
     public MainViewModel()
     {
         Wrapper = new();
+        _logInterpreter = ((App)Application.Current!).LogInterpreter ?? new();
+        Wrapper.OnReceiveLog = HandleLog;
         Wrapper.LoadCore();
         using Stream ndsStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ITDSWrapper.itds.nds")!;
         byte[] data = new byte[ndsStream.Length];
         ndsStream.ReadExactly(data);
         Wrapper.LoadGame(data);
 
-        if (((App)Application.Current!).AudioBackend is not null)
+        if (((App)Application.Current).AudioBackend is not null)
         {
             _audioBackend = ((App)Application.Current).AudioBackend!;
             _audioBackend.Initialize(Wrapper.SampleRate);
@@ -118,8 +120,6 @@ public class MainViewModel : ViewModelBase
         
         _pauseDriver = ((App)Application.Current).PauseDriver ?? new();
         _pauseDriver.AudioBackend = _audioBackend;
-        
-        _logInterpreter = ((App)Application.Current).LogInterpreter ?? new();
 
         _inputDrivers = ((App)Application.Current).InputDrivers ?? [new DefaultInputDriver(IsMobile, OpenSettings)];
         _pointerState = new(EmuRenderWidth, EmuRenderHeight);
@@ -136,7 +136,6 @@ public class MainViewModel : ViewModelBase
         Wrapper.OnSample = PlaySample;
         Wrapper.OnCheckInput = HandleInput;
         Wrapper.OnRumble = DoRumble;
-        Wrapper.OnReceiveLog = HandleLog;
         ThreadPool.QueueUserWorkItem(_ => Run());
     }
 


### PR DESCRIPTION
Rather than try to construct an SD card from scratch, we simply use the SD card that melonDS DS creates. Also switch to using `SparseMemoryStream` as that supports resizing (while `MemoryStream` does not).