### PR TITLE
Add battery monitoring support for desktop and Android

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Facepunch.Steamworks.Package" Version="1.0.5" />
     <PackageVersion Include="Facepunch.Steamworks.Posix" Version="2.4.5" />
     <PackageVersion Include="Facepunch.Steamworks.Win64" Version="2.4.5" />
-    <PackageVersion Include="Hardware.Info" Version="101.0.1.2" />
+    <PackageVersion Include="Hardware.Info" Version="101.0.1.3" />
     <PackageVersion Include="LTRData.DiscUtils.Fat" Version="1.0.64" />
     <PackageVersion Include="NAudio" Version="2.2.1" />
     <PackageVersion Include="NAudio.Sdl2.Library.Android" Version="2.30.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Facepunch.Steamworks.Package" Version="1.0.5" />
     <PackageVersion Include="Facepunch.Steamworks.Posix" Version="2.4.5" />
     <PackageVersion Include="Facepunch.Steamworks.Win64" Version="2.4.5" />
-    <PackageVersion Include="Hardware.Info" Version="101.0.1.1" />
+    <PackageVersion Include="Hardware.Info" Version="101.0.1.2" />
     <PackageVersion Include="LTRData.DiscUtils.Fat" Version="1.0.64" />
     <PackageVersion Include="NAudio" Version="2.2.1" />
     <PackageVersion Include="NAudio.Sdl2.Library.Android" Version="2.30.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Facepunch.Steamworks.Package" Version="1.0.5" />
     <PackageVersion Include="Facepunch.Steamworks.Posix" Version="2.4.5" />
     <PackageVersion Include="Facepunch.Steamworks.Win64" Version="2.4.5" />
+    <PackageVersion Include="Hardware.Info" Version="101.0.1.1" />
     <PackageVersion Include="LTRData.DiscUtils.Fat" Version="1.0.64" />
     <PackageVersion Include="NAudio" Version="2.2.1" />
     <PackageVersion Include="NAudio.Sdl2.Library.Android" Version="2.30.3" />

--- a/ITDSWrapper.Android/AndroidBatteryMonitor.cs
+++ b/ITDSWrapper.Android/AndroidBatteryMonitor.cs
@@ -1,0 +1,13 @@
+using Android.OS;
+using ITDSWrapper.Core;
+
+namespace ITDSWrapper.Android;
+
+public class AndroidBatteryMonitor : IBatteryMonitor
+{
+    public uint GetBatteryLevel()
+    {
+        using BatteryManager batteryManager = new();
+        return (uint)batteryManager.GetIntProperty((int)BatteryProperty.Capacity);
+    }
+}

--- a/ITDSWrapper.Android/MainActivity.cs
+++ b/ITDSWrapper.Android/MainActivity.cs
@@ -56,6 +56,7 @@ public class MainActivity : AvaloniaMainActivity<App>
                 ((App)b.Instance!).AudioBackend = audioBackend;
                 ((App)b.Instance).PauseDriver = _pauseDriver;
                 ((App)b.Instance).HapticsBackend = _hapticsBackend;
+                ((App)b.Instance).BatteryMonitor = new AndroidBatteryMonitor();
             });
     }
 }

--- a/ITDSWrapper.Desktop/BatteryMonitor.cs
+++ b/ITDSWrapper.Desktop/BatteryMonitor.cs
@@ -1,3 +1,4 @@
+using System;
 using Hardware.Info;
 using ITDSWrapper.Core;
 
@@ -11,9 +12,14 @@ public class BatteryMonitor : IBatteryMonitor
         info.RefreshBatteryList();
         if (info.BatteryList.Count == 0 || info.BatteryList[0].DesignCapacity == 0)
         {
+            if (info.BatteryList.Count > 0)
+            {
+                Console.WriteLine(info.BatteryList[0]);
+            }
             return 100;
         }
-
+        
+        Console.WriteLine(info.BatteryList[0]);
         return info.BatteryList[0].EstimatedChargeRemaining;
     }
 }

--- a/ITDSWrapper.Desktop/BatteryMonitor.cs
+++ b/ITDSWrapper.Desktop/BatteryMonitor.cs
@@ -1,0 +1,19 @@
+using Hardware.Info;
+using ITDSWrapper.Core;
+
+namespace ITDSWrapper.Desktop;
+
+public class BatteryMonitor : IBatteryMonitor
+{
+    public uint GetBatteryLevel()
+    {
+        HardwareInfo info = new();
+        info.RefreshBatteryList();
+        if (info.BatteryList.Count == 0 || info.BatteryList[0].DesignCapacity == 0)
+        {
+            return 100;
+        }
+
+        return info.BatteryList[0].EstimatedChargeRemaining;
+    }
+}

--- a/ITDSWrapper.Desktop/ITDSWrapper.Desktop.csproj
+++ b/ITDSWrapper.Desktop/ITDSWrapper.Desktop.csproj
@@ -35,6 +35,7 @@
         <PackageReference Include="Facepunch.Steamworks.Package" />
         <PackageReference Condition="'$(RuntimeIdentifier)' == 'win-x64' Or $([System.OperatingSystem]::IsWindows())" Include="Facepunch.Steamworks.Win64"/>
         <PackageReference Condition="'$(RuntimeIdentifier)' != 'win-x64' And !$([System.OperatingSystem]::IsWindows())" Include="Facepunch.Steamworks.Posix"/>
+        <PackageReference Include="Hardware.Info" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ITDSWrapper.Desktop/Program.cs
+++ b/ITDSWrapper.Desktop/Program.cs
@@ -75,5 +75,7 @@ sealed class Program
                         throw;
                     }
                 }
+
+                ((App)b.Instance!).BatteryMonitor = new BatteryMonitor();
             });
 }

--- a/ITDSWrapper/App.axaml.cs
+++ b/ITDSWrapper/App.axaml.cs
@@ -19,6 +19,7 @@ public partial class App : Application
     public IUpdater? Updater { get; set; }
     public LogInterpreter? LogInterpreter { get; set; }
     public PauseDriver? PauseDriver { get; set; }
+    public IBatteryMonitor? BatteryMonitor { get; set; }
 
     public override void Initialize()
     {

--- a/ITDSWrapper/Core/IBatteryMonitor.cs
+++ b/ITDSWrapper/Core/IBatteryMonitor.cs
@@ -1,0 +1,6 @@
+namespace ITDSWrapper.Core;
+
+public interface IBatteryMonitor
+{
+    public uint GetBatteryLevel();
+}

--- a/ITDSWrapper/ViewModels/MainViewModel.cs
+++ b/ITDSWrapper/ViewModels/MainViewModel.cs
@@ -87,6 +87,9 @@ public class MainViewModel : ViewModelBase
     private readonly List<IInputDriver> _inputDrivers;
     private int _currentInputDriver = 0;
     private readonly PointerState? _pointerState;
+    
+    private readonly IBatteryMonitor? _batteryMonitor;
+    private System.Timers.Timer _batteryTimer;
 
     public VirtualButtonViewModel? AButton { get; set; }
     public VirtualButtonViewModel? BButton { get; set; }
@@ -158,6 +161,15 @@ public class MainViewModel : ViewModelBase
             AssignVirtualBindings();
         }
         
+        _batteryMonitor = ((App)Application.Current).BatteryMonitor;
+        Wrapper.BatteryLevel = _batteryMonitor?.GetBatteryLevel() ?? 100;
+        _batteryTimer = new(TimeSpan.FromMinutes(1)) { AutoReset = true };
+        _batteryTimer.Elapsed += (_, _) =>
+        {
+            Wrapper.BatteryLevel = _batteryMonitor?.GetBatteryLevel() ?? 100;
+        };
+        _batteryTimer.Start();
+        
         Wrapper.OnFrame = DisplayFrame;
         Wrapper.OnSample = PlaySample;
         Wrapper.OnCheckInput = HandleInput;
@@ -224,6 +236,7 @@ public class MainViewModel : ViewModelBase
             {
                 _currentInputDriver = nextInputDriver;
             }
+            
             if (!_pauseDriver.IsPaused())
             {
                 Wrapper.Run();

--- a/Libretro.NET/RetroWrapper.cs
+++ b/Libretro.NET/RetroWrapper.cs
@@ -23,8 +23,8 @@ namespace Libretro.NET
         public uint Height { get; private set; }
         public double FPS { get; private set; }
         public double SampleRate { get; private set; }
+        public uint BatteryLevel { get; set; } = 100;
         public static retro_pixel_format PixelFormat { get; private set; }
-        public retro_core_option_definition[] Options { get; private set; }
 
         public delegate void OnFrameDelegate(byte[] frame, uint width, uint height);
 
@@ -197,6 +197,16 @@ namespace Libretro.NET
                 {
                     retro_core_option_display s = Marshal.PtrToStructure<retro_core_option_display>((IntPtr)data);
                     string value = Marshal.PtrToStringAnsi((IntPtr)((char *)s.key));
+                    return 1;
+                }
+                case RetroBindings.RETRO_ENVIRONMENT_GET_DEVICE_POWER:
+                {
+                    if (data == null)
+                    {
+                        return 1;
+                    }
+
+                    *(uint*)data = BatteryLevel;
                     return 1;
                 }
                 default:


### PR DESCRIPTION
We don't even use this yet in the game, but this adds the ability for the wrapper to track the host device's battery usage and report it to the emulation core which then forwards it to the game.