### PR TITLE
Working multi-touch for virtual buttons on mobile

### DIFF
--- a/ITDSWrapper/Views/Controls/VirtualButtonView.axaml.cs
+++ b/ITDSWrapper/Views/Controls/VirtualButtonView.axaml.cs
@@ -5,7 +5,10 @@ namespace ITDSWrapper.Views.Controls;
 
 public partial class VirtualButtonView : UserControl
 {
+    private const int HoldTimerStart = 5;
+    
     private bool _held;
+    private int _holdTimer = HoldTimerStart;
     
     public VirtualButtonView()
     {
@@ -18,23 +21,32 @@ public partial class VirtualButtonView : UserControl
     {
         if (_held)
         {
+            _holdTimer = HoldTimerStart;
             return;
         }
         
         ((VirtualButtonViewModel?)DataContext)?.Haptics?.Fire(true);
         ((VirtualButtonViewModel?)DataContext)?.AssociatedInput?.Press((VirtualButtonViewModel)DataContext!);
         _held = true;
+        _holdTimer = HoldTimerStart;
     }
 
-    public void ReleaseButton()
+    public void ReleaseButton(bool softRelease = false)
     {
         if (!_held)
         {
             return;
         }
-        
+
+        if (softRelease && _holdTimer > 0)
+        {
+            _holdTimer--;
+            return;
+        }
+
         ((VirtualButtonViewModel?)DataContext)?.Haptics?.Fire(false);
         ((VirtualButtonViewModel?)DataContext)?.AssociatedInput?.Release((VirtualButtonViewModel)DataContext!);
         _held = false;
+        _holdTimer = HoldTimerStart;
     }
 }

--- a/ITDSWrapper/Views/MainView.axaml.cs
+++ b/ITDSWrapper/Views/MainView.axaml.cs
@@ -96,7 +96,7 @@ public partial class MainView : UserControl
         }
         else if (!release)
         {
-            button.ReleaseButton();
+            button.ReleaseButton(softRelease: true);
         }
     }
 


### PR DESCRIPTION
The issue with multi-touch was that multiple touches were "competing" -- i.e., if there were two touches, the first touch was processed as a "release" for the second touch and vice versa. This led to touches constantly iterating.

This PR introduces the concept of a "soft release" -- i.e., a release that doesn't come from the "PointerReleased" event but rather from the _absence_ of a previous touch. For such releases, we have a timer that is reset as long as the button is held. Until the timer ticks to zero, soft releases will not be processed. This effectively enables true multi-touch!